### PR TITLE
Group project under resource instead of groups

### DIFF
--- a/pkg/connector/project.go
+++ b/pkg/connector/project.go
@@ -26,7 +26,6 @@ type projectResourceType struct {
 }
 
 func projectResource(ctx context.Context, project *jira.Project) (*v2.Resource, error) {
-
 	resource, err := rs.NewResource(project.Name, resourceTypeProject, project.ID)
 	if err != nil {
 		return nil, err

--- a/pkg/connector/project.go
+++ b/pkg/connector/project.go
@@ -18,9 +18,6 @@ import (
 var resourceTypeProject = &v2.ResourceType{
 	Id:          "project",
 	DisplayName: "Project",
-	Traits: []v2.ResourceType_Trait{
-		v2.ResourceType_TRAIT_GROUP,
-	},
 }
 
 type projectResourceType struct {
@@ -29,17 +26,8 @@ type projectResourceType struct {
 }
 
 func projectResource(ctx context.Context, project *jira.Project) (*v2.Resource, error) {
-	profile := map[string]interface{}{
-		"name":       project.Name,
-		"project_id": project.ID,
-		"category":   project.ProjectCategory.Name,
-	}
 
-	projectTraitOptions := []rs.GroupTraitOption{
-		rs.WithGroupProfile(profile),
-	}
-
-	resource, err := rs.NewGroupResource(project.Name, resourceTypeProject, project.ID, projectTraitOptions)
+	resource, err := rs.NewResource(project.Name, resourceTypeProject, project.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -295,9 +283,8 @@ func (u *projectResourceType) List(ctx context.Context, _ *v2.ResourceId, p *pag
 	var resources []*v2.Resource
 	for _, project := range projects {
 		resource, err := projectResource(ctx, &jira.Project{
-			Name:            project.Name,
-			ID:              project.ID,
-			ProjectCategory: project.ProjectCategory,
+			Name: project.Name,
+			ID:   project.ID,
 		})
 
 		if err != nil {


### PR DESCRIPTION
The projects were erroneously labelled as groups, fixed this issue. Also removed the ProjectCategory trait that is currently unused. 
<img width="1652" alt="image" src="https://github.com/ConductorOne/baton-jira/assets/60042005/cc2f886a-3e3d-4ee8-932b-e4402b8f73e4">
