### PR TITLE
Fixed roles not being associated with a project

### DIFF
--- a/pkg/connector/helpers.go
+++ b/pkg/connector/helpers.go
@@ -2,8 +2,11 @@ package connector
 
 import (
 	"fmt"
+	"net/url"
 	"regexp"
+	"slices"
 	"strconv"
+	"strings"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/pagination"
@@ -62,23 +65,35 @@ func getPageTokenFromOffset(bag *pagination.Bag, offset int64) (string, error) {
 	return pageToken, nil
 }
 
+var RoleIDNotFoundErr = fmt.Errorf("role id not found in role link")
+
 // Unfortunatelly, the Jira API does not provide a way to get the role id from project.
 // It only provides a link to the role. Like this: https://your-domain.atlassian.net/rest/api/3/project/10001/role/10002
 // So, we need to parse the role id from the link.
 func parseRoleIdFromRoleLink(roleLink string) (int, error) {
-	regexPattern := `\/(\d+)\/?$` // Regex pattern to match the last number in the URL path
-	r := regexp.MustCompile(regexPattern)
-
-	matches := r.FindStringSubmatch(roleLink)
-
-	if len(matches) < 2 {
-		return 0, fmt.Errorf("failed to parse role id from role link")
-	}
-
-	lastNumber, err := strconv.Atoi(matches[1])
+	// Parse the URL
+	parsedURL, err := url.Parse(roleLink)
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("failed to parse URL: %w", err)
 	}
 
-	return lastNumber, nil
+	// Split the path of the URL
+	pathElems := strings.Split(parsedURL.Path, "/")
+	// Find the index of the "role" element in the path, the next element should be the role id
+	roleIndex := slices.Index(pathElems, "role")
+	if roleIndex == -1 || roleIndex+1 >= len(pathElems) {
+		return 0, RoleIDNotFoundErr
+	}
+	regexPattern := `\d+` // Regex pattern to match any number in the URL path
+	r := regexp.MustCompile(regexPattern)
+	matches := r.FindStringSubmatch(pathElems[roleIndex+1])
+	// If there are no matches, return an error
+	if len(matches) == 0 {
+		return 0, RoleIDNotFoundErr
+	}
+	roleID, err := strconv.Atoi(matches[0])
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse role id: %w", err)
+	}
+	return roleID, nil
 }

--- a/pkg/connector/helpers.go
+++ b/pkg/connector/helpers.go
@@ -2,6 +2,7 @@ package connector
 
 import (
 	"fmt"
+	"regexp"
 	"strconv"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
@@ -59,4 +60,25 @@ func getPageTokenFromOffset(bag *pagination.Bag, offset int64) (string, error) {
 	}
 
 	return pageToken, nil
+}
+
+// Unfortunatelly, the Jira API does not provide a way to get the role id from project.
+// It only provides a link to the role. Like this: https://your-domain.atlassian.net/rest/api/3/project/10001/role/10002
+// So, we need to parse the role id from the link.
+func parseRoleIdFromRoleLink(roleLink string) (int, error) {
+	regexPattern := `\/(\d+)\/?$` // Regex pattern to match the last number in the URL path
+	r := regexp.MustCompile(regexPattern)
+
+	matches := r.FindStringSubmatch(roleLink)
+
+	if len(matches) < 2 {
+		return 0, fmt.Errorf("failed to parse role id from role link")
+	}
+
+	lastNumber, err := strconv.Atoi(matches[1])
+	if err != nil {
+		return 0, err
+	}
+
+	return lastNumber, nil
 }

--- a/pkg/connector/project.go
+++ b/pkg/connector/project.go
@@ -3,6 +3,7 @@ package connector
 import (
 	"context"
 	"fmt"
+
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/pagination"

--- a/pkg/connector/project.go
+++ b/pkg/connector/project.go
@@ -3,9 +3,6 @@ package connector
 import (
 	"context"
 	"fmt"
-	"regexp"
-	"strconv"
-
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/pagination"
@@ -258,27 +255,6 @@ func getRoleGrants(ctx context.Context, p *projectResourceType, resource *v2.Res
 	}
 
 	return rv, nil
-}
-
-// Unfortunatelly, the Jira API does not provide a way to get the role id from project.
-// It only provides a link to the role. Like this: https://your-domain.atlassian.net/rest/api/3/project/10001/role/10002
-// So, we need to parse the role id from the link.
-func parseRoleIdFromRoleLink(roleLink string) (int, error) {
-	regexPattern := `\/(\d+)\/?$` // Regex pattern to match the last number in the URL path
-	r := regexp.MustCompile(regexPattern)
-
-	matches := r.FindStringSubmatch(roleLink)
-
-	if len(matches) < 2 {
-		return 0, fmt.Errorf("failed to parse role id from role link")
-	}
-
-	lastNumber, err := strconv.Atoi(matches[1])
-	if err != nil {
-		return 0, err
-	}
-
-	return lastNumber, nil
 }
 
 func (u *projectResourceType) List(ctx context.Context, _ *v2.ResourceId, p *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {

--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -3,6 +3,8 @@ package connector
 import (
 	"context"
 	"fmt"
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+	"go.uber.org/zap"
 	"strconv"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
@@ -194,9 +196,10 @@ func (u *roleResourceType) mapRoleIDsToProjectNames(ctx context.Context) (map[in
 }
 
 func (u *roleResourceType) List(ctx context.Context, _ *v2.ResourceId, _ *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
+	l := ctxzap.Extract(ctx)
 	roleIDToProjectName, err := u.mapRoleIDsToProjectNames(ctx)
 	if err != nil {
-		return nil, "", nil, wrapError(err, "failed to map role IDs to project names")
+		l.Error(wrapError(err, "failed to map role IDs to project names").Error(), zap.Error(err))
 	}
 	roles, _, err := u.client.Role.GetList(ctx)
 	if err != nil {

--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -3,8 +3,6 @@ package connector
 import (
 	"context"
 	"fmt"
-	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
-	"go.uber.org/zap"
 	"strconv"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
@@ -14,6 +12,8 @@ import (
 	grant "github.com/conductorone/baton-sdk/pkg/types/grant"
 	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
 	jira "github.com/conductorone/go-jira/v2/cloud"
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+	"go.uber.org/zap"
 )
 
 var resourceTypeRole = &v2.ResourceType{

--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -195,6 +195,9 @@ func (u *roleResourceType) mapRoleIDsToProjectNames(ctx context.Context) (map[in
 
 func (u *roleResourceType) List(ctx context.Context, _ *v2.ResourceId, _ *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
 	roleIDToProjectName, err := u.mapRoleIDsToProjectNames(ctx)
+	if err != nil {
+		return nil, "", nil, wrapError(err, "failed to map role IDs to project names")
+	}
 	roles, _, err := u.client.Role.GetList(ctx)
 	if err != nil {
 		return nil, "", nil, wrapError(err, "failed to get roles")


### PR DESCRIPTION
Now the role names are prepended with the project name. I had to list the projects then get each of them individually, the listed projects dont have a roles field. Then I iterated over the roles and mapped the role id to a project name. This mapping was used later on to prepend the project name

![image](https://github.com/ConductorOne/baton-jira/assets/60042005/e350d857-7b5e-42a9-8475-17dfdb73f47e)
