### PR TITLE
[BB-1396] jira: handle pageToken

### DIFF
--- a/pkg/connector/helpers.go
+++ b/pkg/connector/helpers.go
@@ -54,7 +54,7 @@ func parsePageToken(i string, resourceID *v2.ResourceId) (*pagination.Bag, int64
 	}
 
 	offset, err := getOffsetFromPageToken(b.PageToken())
-	if err != nil {
+	if err != nil && b.ResourceTypeID() != siteUsers && b.ResourceTypeID() != siteGroups {
 		return nil, 0, err
 	}
 

--- a/pkg/connector/helpers.go
+++ b/pkg/connector/helpers.go
@@ -53,8 +53,12 @@ func parsePageToken(i string, resourceID *v2.ResourceId) (*pagination.Bag, int64
 		})
 	}
 
+	if rID := b.ResourceTypeID(); rID == siteUsers || rID == siteGroups {
+		return b, 0, nil
+	}
+
 	offset, err := getOffsetFromPageToken(b.PageToken())
-	if err != nil && b.ResourceTypeID() != siteUsers && b.ResourceTypeID() != siteGroups {
+	if err != nil {
 		return nil, 0, err
 	}
 


### PR DESCRIPTION
PageToken returned from atlassian API is string type instead of int type. 
the error is : 
```
"error: listing resources failed: strconv.ParseInt: parsing \"eyJsaW1pdCI6MSwic29ydEJ5IjpudWxsLCJhY2NvdW50SWRzIjpudWxsLCJkaXJlY3RvcnlJZHMiOm51bGwsImdyb3VwSWRzIjpudWxsLCJyb2xlSWRzIjpudWxsLCJyZXNvdXJjZUlkcyI6WyJhcmk6Y2xvdWQ6amlyYS1zb2Z0d2FyZTo6c2l0ZS8zZTNmMWUyYy1lNjI3LTRmYTMtODY2MS0zYjNmMjI1YTNlNjEiXSwic2VhcmNoVGVybSI6bnVsbCwiY2xhaW1TdGF0dXMiOm51bGwsImFjY291bnRTdGF0dXMiOm51bGwsIm1lbWJlcnNoaXBTdGF0dXMiOm51bGwsInN0YXR1cyI6bnVsbCwibGFzdEN1cnNvclZhbHVlIjoiQmVuIFN1IiwibGFzdEFjY291bnRBcmkiOiJhcmk6Y2xvdWQ6aWRlbnRpdHk6OnVzZXIvNzEyMDIwOmQ2MWRmMTExLWZlODgtNGY5NS05MmIxLWRlODU0NDgxZWJjMiIsImN1cnNvckRpcmVjdGlvbiI6Im5leHQifQ==\": invalid syntax", "grpc.code": "Unknown", "grpc.time_ms": 0.066
```

in the fix, we shouldn’t throw an error when the resource type is siteUsers or siteGroups.

### Test.
1. reproduce the error. 
<img width="1512" height="539" alt="image" src="https://github.com/user-attachments/assets/a605e0fd-1598-490a-8fc7-403ab020e0b6" />
2. fix it.
<img width="1506" height="470" alt="image" src="https://github.com/user-attachments/assets/fe7875e3-ccf3-4779-a3b4-ab48cf46dc0f" />
