### PR TITLE
handle 404s in Grants

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -21,36 +21,36 @@ func (c *Client) Jira() *jira.Client {
 	return c.jira
 }
 
-func (c *Client) GetProject(ctx context.Context, projectID string) (*jira.Project, error) {
+func (c *Client) GetProject(ctx context.Context, projectID string) (*jira.Project, *jira.Response, error) {
 	project, ok := c.projectCache.Load(projectID)
 	if ok {
-		return project.(*jira.Project), nil
+		return project.(*jira.Project), nil, nil
 	}
 
-	prj, _, err := c.jira.Project.Get(ctx, projectID)
+	prj, resp, err := c.jira.Project.Get(ctx, projectID)
 	if err != nil {
-		return nil, err
+		return nil, resp, err
 	}
 
 	c.projectCache.Store(projectID, prj)
 
-	return prj, nil
+	return prj, resp, nil
 }
 
-func (c *Client) GetRole(ctx context.Context, roleID int) (*jira.Role, error) {
+func (c *Client) GetRole(ctx context.Context, roleID int) (*jira.Role, *jira.Response, error) {
 	role, ok := c.roleCache.Load(roleID)
 	if ok {
-		return role.(*jira.Role), nil
+		return role.(*jira.Role), nil, nil
 	}
 
-	r, _, err := c.jira.Role.Get(ctx, roleID)
+	r, resp, err := c.jira.Role.Get(ctx, roleID)
 	if err != nil {
-		return nil, err
+		return nil, resp, err
 	}
 
 	c.roleCache.Store(roleID, r)
 
-	return r, nil
+	return r, resp, nil
 }
 
 func New(url string, httpClient *http.Client) (*Client, error) {

--- a/pkg/connector/project.go
+++ b/pkg/connector/project.go
@@ -76,9 +76,13 @@ func (u *projectResourceType) Entitlements(ctx context.Context, resource *v2.Res
 }
 
 func (p *projectResourceType) Grants(ctx context.Context, resource *v2.Resource, pt *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
-	project, err := p.client.GetProject(ctx, resource.Id.Resource)
+	project, resp, err := p.client.GetProject(ctx, resource.Id.Resource)
 	if err != nil {
-		return nil, "", nil, wrapError(err, "failed to get project", nil)
+		var statusCode *int
+		if resp != nil {
+			statusCode = &resp.StatusCode
+		}
+		return nil, "", nil, wrapError(err, "failed to get project", statusCode)
 	}
 
 	var rv []*v2.Grant

--- a/pkg/connector/project_role.go
+++ b/pkg/connector/project_role.go
@@ -71,14 +71,22 @@ func (u *projectRoleResourceType) Entitlements(ctx context.Context, resource *v2
 		return nil, "", nil, wrapError(err, "failed to parse project role ID", nil)
 	}
 
-	project, err := u.client.GetProject(ctx, projectID)
+	project, resp, err := u.client.GetProject(ctx, projectID)
 	if err != nil {
-		return nil, "", nil, wrapError(err, "failed to get project", nil)
+		var statusCode *int
+		if resp != nil {
+			statusCode = &resp.StatusCode
+		}
+		return nil, "", nil, wrapError(err, "failed to get project", statusCode)
 	}
 
-	role, err := u.client.GetRole(ctx, roleID)
+	role, resp, err := u.client.GetRole(ctx, roleID)
 	if err != nil {
-		return nil, "", nil, wrapError(err, "failed to get role", nil)
+		var statusCode *int
+		if resp != nil {
+			statusCode = &resp.StatusCode
+		}
+		return nil, "", nil, wrapError(err, "failed to get role", statusCode)
 	}
 
 	assigmentOptions := []ent.EntitlementOption{
@@ -158,9 +166,13 @@ func (p *projectRoleResourceType) List(ctx context.Context, _ *v2.ResourceId, to
 
 	var ret []*v2.Resource
 	for _, prj := range projects {
-		project, err := p.client.GetProject(ctx, prj.ID)
+		project, resp, err := p.client.GetProject(ctx, prj.ID)
 		if err != nil {
-			return nil, "", nil, wrapError(err, fmt.Sprintf("failed to get project %s", prj.ID), nil)
+			var statusCode *int
+			if resp != nil {
+				statusCode = &resp.StatusCode
+			}
+			return nil, "", nil, wrapError(err, fmt.Sprintf("failed to get project %s", prj.ID), statusCode)
 		}
 		for _, roleLink := range project.Roles {
 			roleId, err := parseRoleIdFromRoleLink(roleLink)
@@ -168,9 +180,13 @@ func (p *projectRoleResourceType) List(ctx context.Context, _ *v2.ResourceId, to
 				return nil, "", nil, wrapError(err, "failed to parse role id from role link", nil)
 			}
 
-			role, err := p.client.GetRole(ctx, roleId)
+			role, resp, err := p.client.GetRole(ctx, roleId)
 			if err != nil {
-				return nil, "", nil, wrapError(err, "failed to get role", nil)
+				var statusCode *int
+				if resp != nil {
+					statusCode = &resp.StatusCode
+				}
+				return nil, "", nil, wrapError(err, "failed to get role", statusCode)
 			}
 
 			prr, err := projectRoleResource(project, role)

--- a/pkg/connector/tickets.go
+++ b/pkg/connector/tickets.go
@@ -407,9 +407,13 @@ func (j *Jira) GetTicketSchema(ctx context.Context, schemaID string) (*v2.Ticket
 		return nil, nil, err
 	}
 
-	project, err := j.client.GetProject(ctx, projectKeyIssueTypeID.ProjectKey)
+	project, resp, err := j.client.GetProject(ctx, projectKeyIssueTypeID.ProjectKey)
 	if err != nil {
-		return nil, nil, err
+		var statusCode *int
+		if resp != nil {
+			statusCode = &resp.StatusCode
+		}
+		return nil, nil, wrapError(err, "failed to get project", statusCode)
 	}
 
 	issueType := findIssueTypeFromProject(project, projectKeyIssueTypeID.IssueTypeID)


### PR DESCRIPTION
Wraps all the `GetProjects` and `GetRoles` client calls with status code. In particular, this fixes 404 not found cases for projects in `Grants` which were causing connectors to fail syncs when customers deleted projects in jira right beforehand.