### PR TITLE
Update connector page title to include parent company name

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -1,7 +1,7 @@
 ---
-title:"Set up an Atlassian Jira Cloud connector"
+title: "Set up an Atlassian Jira Cloud connector"
 description: "C1 provides identity governance for Jira Cloud. Integrate your Jira Cloud instance with C1 to run user access reviews (UARs) and enable just-in-time access requests."
-og:title:"Set up an Atlassian Jira Cloud connector"
+og:title: "Set up an Atlassian Jira Cloud connector"
 og:description: "C1 provides identity governance for Jira Cloud. Integrate your Jira Cloud instance with C1 to run user access reviews (UARs) and enable just-in-time access requests."
 sidebarTitle: "Atlassian Jira Cloud"
 ---

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -1,7 +1,7 @@
 ---
-title: "Set up a Jira Cloud connector"
+title:"Set up an Atlassian Jira Cloud connector"
 description: "C1 provides identity governance for Jira Cloud. Integrate your Jira Cloud instance with C1 to run user access reviews (UARs) and enable just-in-time access requests."
-og:title: "Set up a Jira Cloud connector"
+og:title:"Set up an Atlassian Jira Cloud connector"
 og:description: "C1 provides identity governance for Jira Cloud. Integrate your Jira Cloud instance with C1 to run user access reviews (UARs) and enable just-in-time access requests."
 sidebarTitle: "Atlassian Jira Cloud"
 ---
@@ -103,7 +103,7 @@ If you want to set up the Jira Cloud connector to sync managed accounts and mana
     </Step>
 </Steps>
 
-**That's it!** Next, move on to the connector configuration instructions.
+**Done.** Next, move on to the connector configuration instructions.
 
 ## Configure the Jira Cloud connector
 
@@ -161,7 +161,7 @@ If you want to set up the Jira Cloud connector to sync managed accounts and mana
     </Step>
 </Steps>
 
-**That's it!** Your Jira Cloud connector is now pulling access data into C1.
+**Done.** Your Jira Cloud connector is now pulling access data into C1.
 </Tab>
 <Tab title="Self-hosted">
 **Follow these instructions to use the Jira connector, hosted and run in your own environment.**
@@ -289,7 +289,7 @@ spec:
     </Step>
 </Steps>
 
-**That's it!** Your Jira Cloud connector is now pulling access data into C1.
+**Done.** Your Jira Cloud connector is now pulling access data into C1.
 </Tab>
 </Tabs>
 


### PR DESCRIPTION
This PR updates the connector page title and og:title to include the parent company name for better discoverability and consistency across connector docs.

Also replaces any remaining instances of `That's it!` with `Done.`