### PR TITLE
docs: update connector name and style to match docs site

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -43,6 +43,7 @@ The Jira Cloud user account used to generate these credentials must have the fol
 - View project roles
 - Manage group memberships (required if you are using the connector for provisioning)
 - Manage project role memberships (required if you are using the connector for provisioning)
+- Browse Projects (required if you are using the connector as an external ticketing provider)
 - Create issues (required if you are using the connector as an external ticketing provider)
 </Warning>
 
@@ -292,3 +293,5 @@ spec:
 **Done.** Your Jira Cloud connector is now pulling access data into C1.
 </Tab>
 </Tabs>
+
+


### PR DESCRIPTION
## Summary

Syncs `docs/connector.mdx` with the canonical docs site.

Changes include:
- Updated connector/product name in title, og:title, description, og:description, and sidebarTitle
- Style updates (ECR image URL, `**Done.**` phrasing, icon color, C1 branding)

The docs site is the source of truth for connector page content.