### PR TITLE
docs: add scoped API token permissions reference

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -69,6 +69,23 @@ You can set up the connector using either a classic (unscoped) or a scoped token
     </Step>
 </Steps>
 
+If creating a scoped token, select the permissions you need based on your requirements. Not all permissions are required for every use case:
+
+- Scope:   `read:jira-user` <br/>
+  Purpose: Sync users and groups.
+
+- Scope:   `read:jira-work` <br/>
+  Purpose: Sync projects and roles; read issue data, schemas, and statuses.
+
+- Scope:   `write:jira-work` <br/>
+  Purpose: Create tickets (required if using the connector as an external ticketing provider).
+
+- Scope:   `manage:jira-project` <br/>
+  Purpose: Provision project role membership.
+
+- Scope:   `manage:jira-configuration` <br/>
+  Purpose: Provision group membership.
+
 ### Additional credentials
 
 To set up the connector, you'll also need:


### PR DESCRIPTION
## Summary

- Adds a permissions reference for scoped API tokens in the Jira Cloud connector setup guide
- Lists the five available OAuth scopes (`read:jira-user`, `read:jira-work`, `write:jira-work`, `manage:jira-project`, `manage:jira-configuration`) with their purposes
- Clarifies that users should select only the permissions required for their use case

Mirrors change from ConductorOne/docs#338.