### PR TITLE
fix: CreateAccount honors the operator-mapped email field

### DIFF
--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -264,10 +264,35 @@ func getCreateInvitationBody(accountInfo *v2.AccountInfo) (*client.CreateUserBod
 		}
 	}
 
+	email, err := getEmailFromAccountInfo(accountInfo, pMap)
+	if err != nil {
+		return nil, err
+	}
+
 	return &client.CreateUserBody{
-		Email:    accountInfo.Login,
+		Email:    email,
 		Products: products,
 	}, nil
+}
+
+func getEmailFromAccountInfo(accountInfo *v2.AccountInfo, pMap map[string]interface{}) (string, error) {
+	if emailValue, exists := pMap["email"]; exists && emailValue != nil {
+		emailStr, ok := emailValue.(string)
+		if !ok {
+			return "", fmt.Errorf("email field is not a string: %T", emailValue)
+		}
+		if emailStr != "" {
+			return emailStr, nil
+		}
+	}
+
+	for _, e := range accountInfo.GetEmails() {
+		if e.GetAddress() != "" {
+			return e.GetAddress(), nil
+		}
+	}
+
+	return accountInfo.GetLogin(), nil
 }
 
 func (b *userResourceType) listSiteUsers(ctx context.Context, _ *v2.ResourceId, attrs rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -286,10 +286,22 @@ func getEmailFromAccountInfo(accountInfo *v2.AccountInfo, pMap map[string]interf
 		}
 	}
 
+	// Prefer the primary email; fall back to the first non-empty address.
+	firstSet := ""
 	for _, e := range accountInfo.GetEmails() {
-		if e.GetAddress() != "" {
-			return e.GetAddress(), nil
+		addr := e.GetAddress()
+		if addr == "" {
+			continue
 		}
+		if e.GetIsPrimary() {
+			return addr, nil
+		}
+		if firstSet == "" {
+			firstSet = addr
+		}
+	}
+	if firstSet != "" {
+		return firstSet, nil
 	}
 
 	return accountInfo.GetLogin(), nil


### PR DESCRIPTION
## Summary

Fixes [CE-936](https://linear.app/ductone/issue/CE-936): baton-jira `CreateAccount` ignored the operator-mapped email field.

`getCreateInvitationBody` read the new user's email from `accountInfo.Login` (the C1 identity login) instead of the operator-mapped account-creation schema field at `profile.email`, so the mapped email was never sent to Jira.

## Change

New `getEmailFromAccountInfo` helper resolves the email in priority order:

1. `accountInfo.Profile["email"]` — operator-mapped value (type-checked; errors if present but non-string)
2. first non-empty `accountInfo.Emails[].Address`
3. `accountInfo.Login` — last resort

## Follow-up

`baton-axiomatic-jira` PR #11 intentionally mirrors the old login-read for parity with the native connector. Once this merges, the axiomatic connector should be updated to match (tracked under CE-936).
